### PR TITLE
Compile with C++11 including with CMake as old as 3.0.2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -13,7 +13,13 @@ project(iagmm)
 # The line below cleanly ensure release builds have O3 optimization level.
 add_compile_options("$<$<CONFIG:RELEASE>:-O3>")
 
-set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
+if (CMAKE_VERSION VERSION_LESS "3.1")
+  if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    add_compile_options("-std=c++11")
+  endif ()
+else ()
+  set (CMAKE_CXX_STANDARD 11)
+endif ()
 
 option(VERBOSE_RUNTIME "Set true to create a build with more run-time output." FALSE)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -11,7 +11,7 @@ project(iagmm)
 
 # Eigen runs much much much faster when compiled in -O3.
 # The line below cleanly ensure release builds have O3 optimization level.
-add_compile_options("$<$<CONFIG:RELEASE>:-O3 -std=c++11>")
+add_compile_options("$<$<CONFIG:RELEASE>:-O3>")
 
 set(CMAKE_CXX_FLAGS "-std=c++11 ${CMAKE_CXX_FLAGS}")
 


### PR DESCRIPTION
Warning: add_compile_options line did not work because it assumes only one option, no spaces. Hence, "-O3 -std=c++11" would appear as string during compilation and fail.

Implement clean solution following [c++11 - How to activate C++ 11 in CMake? - Stack Overflow](https://stackoverflow.com/questions/10851247/how-to-activate-c-11-in-cmake/31010221#31010221 "c++11 - How to activate C++ 11 in CMake? - Stack Overflow")
